### PR TITLE
Enable trailingSlash option to ensure correct routing for GitHub Pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const withNextra = require('nextra')({
 })
  
 nextraConfig = withNextra({
+  trailingSlash: true,
   output: 'export',
   images: {
     unoptimized: true,


### PR DESCRIPTION
Ensures URLs with trailing slashes (/deployment/) correctly map to directories with index.html files (deployment/index.html), fixing the issue of direct URL access resulting in 403 errors or directory listings.

Closes #20 